### PR TITLE
Prepare for 5.2 AST bump

### DIFF
--- a/ppx_default.ml
+++ b/ppx_default.ml
@@ -79,6 +79,7 @@ let default_fun ~loc ~ptype_name expr =
         pvb_expr = expr;
         pvb_attributes = [];
         pvb_loc = loc;
+        pvb_constraint = None;
       };
     ]
 


### PR DESCRIPTION
This PR is a patch for an upcoming release of ppxlib where the internal AST is [bumped from 4.14 to 5.2](https://github.com/ocaml-ppx/ppxlib/pull/514). Until that is merged and released, there is no reason to merge this PR.

To test these changes, you can use the following opam-based workflow. I've made releases of most of these patches to an opam-repository overlay.

```shell
opam switch create ppxlib-bump --repos=ppxlib=git+https://github.com/patricoferris/opam-repository#5.2-ast-bump
opam install <your-package>
```

The following describes the most notable changes to the AST.

Note: no update has been made of the `opam` file, but `ppxlib` will likely need a lower-bound before merging/releasing.

### Functions
---

#### Currently 

In the parsetree currently, functions like:

```ocaml
fun x y z -> ...
```

Are represented roughly as

```ocaml
Pexp_fun(x, Pexp_fun (y, Pexp_fun(z, ...)))
```

Functions like:

```ocaml
function A -> ... | B -> ...
```

Are represented roughly as

```ocaml
Pexp_function ([ case A; case B ])
```

#### Since 5.2

All of these functions now map to a single AST node `Pexp_function` (note, this is the same name as the old cases function). The first argument is a list of parameters meaning:

```ocaml
fun x y z -> ...
```

Now looks like:

```ocaml
Pexp_function([x; y; z], _constraint, body)
```

And the `body` is where we can either have _more_ expressions (`Pfunction_body _`) or cases (`Pfunction_cases _`). That means:

```ocaml
function A -> ... | B -> ...
```

Has an empty list of parameters:

```ocaml
Pexp_function([], _, Pfunction_cases ([case A; case B]))
```

### Local Module Opens for Types

Another feature added in 5.2 was the ability to locally open modules in type definitions. 

```ocaml
module M = struct
  type t = A | B | C
end

type t = Local_open_coming of M.(t)
```

This has a `Ptyp_open (module_identifier, core_type)` AST node. Just like normal module opens this does create some syntactic ambiguity about where things come from inside the parentheses.